### PR TITLE
Allow top level section IDs to contain level separators

### DIFF
--- a/lib/section-ids-extension.js
+++ b/lib/section-ids-extension.js
@@ -27,15 +27,24 @@ function createExtensionGroup () {
 function validate (section, wordSeparator, levelSeparator, validLocalRx) {
   const id = section.getId()
   if (!id) return
-  let localId = id
   if (section.getContext() !== 'document') {
     const lastLevelSeparatorIdx = id.lastIndexOf(levelSeparator)
     const idNamespace = id.slice(0, lastLevelSeparatorIdx)
-    localId = id.slice(lastLevelSeparatorIdx + 1)
+    const localId = id.slice(lastLevelSeparatorIdx + 1)
     const parentId = (nearest(section.getParent(), 'section') || section.getDocument()).getId()
     if (idNamespace !== parentId) warn.call(section, `expecting section ID to start with ${parentId}: ${id}`)
+    if (!validLocalRx.test(localId)) warn.call(section, `local section ID does not match ${validLocalRx.source}: ${id}`)
+  } else {
+    const parts = id.split(levelSeparator)
+    for (const part of parts) {
+      if (!validLocalRx.test(part)) {
+        warn.call(
+          section,
+          `local section ID does not match ${validLocalRx.source}: ${id}${parts.length !== 1 ? ' (' + part + ')' : ''}`
+        )
+      }
+    }
   }
-  if (!validLocalRx.test(localId)) warn.call(section, `local section ID does not match ${validLocalRx.source}: ${id}`)
 }
 
 function warn (message) {

--- a/test/section-ids-extension-test.js
+++ b/test/section-ids-extension-test.js
@@ -102,6 +102,26 @@ describe('section-ids-extension', () => {
       })
     })
 
+    it('should warn if document ID with level separator does not match expected syntax', () => {
+      const input = heredoc`
+      [[foo.id_of_document]]
+      = Document Title
+
+      content
+      `
+      withMemoryLogger((logger) => {
+        run(input)
+        const messages = logger.getMessages()
+        expect(messages).to.have.lengthOf(1)
+        const message = messages[0]
+        expect(message.severity).to.equal('WARN')
+        console.log(message.message.text)
+        expect(message.message.text).to.match(
+          /^local section ID does not match .+: foo.id_of_document \(id_of_document\)$/
+        )
+      })
+    })
+
     it('should include file and line information in log message if sourcemap is enabled', () => {
       const input = heredoc`
       [#not_valid]
@@ -127,7 +147,7 @@ describe('section-ids-extension', () => {
       })
     })
 
-    it('should warn if document ID contains level separator', () => {
+    it('should validate if document ID contains level separator', () => {
       const input = heredoc`
       [[document.title]]
       = Document Title
@@ -136,11 +156,7 @@ describe('section-ids-extension', () => {
       `
       withMemoryLogger((logger) => {
         run(input)
-        const messages = logger.getMessages()
-        expect(messages).to.have.lengthOf(1)
-        const message = messages[0]
-        expect(message.severity).to.equal('WARN')
-        expect(message.message.text).to.match(/^local section ID does not match .+: document\.title$/)
+        expect(logger.getMessages()).to.be.empty()
       })
     })
 


### PR DESCRIPTION
Update `section-ids-extension` so that top level sections IDs can contain level separators.

Prior to this commit, a top-level separator of the following form:

	[[foo.bar]]
	= Heading

Would produce a "local section ID does not match..." warning.

Closes #7