### PR TITLE
Support map ancestors when finding configuration properties

### DIFF
--- a/lib/configuration-properties-extension.js
+++ b/lib/configuration-properties-extension.js
@@ -150,8 +150,8 @@ function log (node, severity, message) {
 }
 
 function validateConfigurationProperty (node, configurationProperties, name, deprecated) {
-  if (name in configurationProperties) {
-    const property = configurationProperties[name]
+  const property = findConfigurationProperty(configurationProperties, name)
+  if (property) {
     if (property.deprecated) {
       if (!deprecated) log(node, 'warn', `configuration property is deprecated: ${name}`)
     } else if (deprecated) {
@@ -161,6 +161,20 @@ function validateConfigurationProperty (node, configurationProperties, name, dep
   } else {
     log(node, 'warn', `configuration property not found: ${name}`)
   }
+}
+
+function findConfigurationProperty (configurationProperties, name) {
+  const property = configurationProperties[name]
+  if (property) return property
+  const parts = name.split('.')
+  while (parts.length > 0) {
+    parts.pop()
+    const candidate = configurationProperties[parts.join('.')]
+    if (candidate?.map) {
+      return candidate
+    }
+  }
+  return null
 }
 
 module.exports = { register, createExtensionGroup }

--- a/test/configuration-properties-extension-test.js
+++ b/test/configuration-properties-extension-test.js
@@ -233,6 +233,18 @@ describe('configuration-properties-extension', () => {
       expect(messages).to.be.empty()
     })
 
+    it('should convert valid property to monospaced phrase without warning when has map ancestor', () => {
+      addConfigurationMetadataFixture({ name: 'management.observations.enable', type: 'java.util.Map<String, String>' })
+      const input = heredoc`
+      = Page Title
+
+      configprop:management.observations.enable.my.key[]
+      `
+      const actual = run(input, { convert: true })
+      expect(actual).to.include('<code>management.observations.enable.my.key</code>')
+      expect(messages).to.be.empty()
+    })
+
     it('should convert valid property as env var to monospaced phrase if format=envvar is set', () => {
       addConfigurationMetadataFixture({ name: 'foo.bar.baz-name' })
       const input = heredoc`


### PR DESCRIPTION
Update `configuration-properties-extension` so that map ancestors are found when searching for properties.

Fixes gh-9