### PR TITLE
Support javadoc lookup when package name has a single component

### DIFF
--- a/lib/javadoc-extension.js
+++ b/lib/javadoc-extension.js
@@ -54,12 +54,11 @@ function createLinkMarkup (document, target, description, attributes) {
 
 function getTargetLocation (document, target) {
   let name = target.packageReference
-  let lastDot = name.lastIndexOf('.')
-  while (lastDot > 0) {
+  while (name !== '') {
     const location = document.getAttribute('javadoc-location-' + name.replaceAll('.', '-'))
     if (location) return location
-    name = name.substring(0, lastDot)
-    lastDot = name.lastIndexOf('.')
+    const lastDot = name.lastIndexOf('.')
+    name = lastDot > 0 ? name.substring(0, lastDot) : ''
   }
   return document.getAttribute('javadoc-location', 'xref:attachment$api/java')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "js-yaml": "~4.1"
       },
       "devDependencies": {
-        "@antora/asciidoc-loader": "*",
-        "@asciidoctor/core": "*",
+        "@antora/asciidoc-loader": "latest",
+        "@asciidoctor/core": "latest",
         "@asciidoctor/tabs": "1.0.0-beta.6",
         "chai": "~4.3",
         "chai-fs": "~2.0",

--- a/test/include-code-extension-test.js
+++ b/test/include-code-extension-test.js
@@ -307,6 +307,7 @@ describe('include-code-extension', () => {
       include-code::hello[sync-group-id=thisisauniqueid]
       `
       const actual = run(input, { registerAsciidoctorTabs: true })
+      console.log(actual.convert())
       expect(actual.convert()).to.contain(
         'class="openblock tabs is-sync data-sync-group-id=thisisauniqueid is-loading"'
       )

--- a/test/javadoc-extension-test.js
+++ b/test/javadoc-extension-test.js
@@ -159,6 +159,25 @@ describe('javadoc-extension', () => {
       )
     })
 
+    it('should convert with specified location when has single name package specific javadoc-location attributes', () => {
+      const input = heredoc`
+        = Page Title
+        :javadoc-location: xref:api:java
+        :javadoc-location-java: xref:api:e1
+        :javadoc-location-graphql: xref:api:e2
+
+        javadoc:java.util.ZipFile[]
+        javadoc:graphql.collect.ImmutableKit[]
+        `
+      const actual = run(input)
+      expect(actual).to.include(
+        '<a href="https://docs.example.com/api/e1/java/util/ZipFile.html" class="xref page apiref"><code>ZipFile</code></a>'
+      )
+      expect(actual).to.include(
+        '<a href="https://docs.example.com/api/e2/graphql/collect/ImmutableKit.html" class="xref page apiref"><code>ImmutableKit</code></a>'
+      )
+    })
+
     it('should convert with specified location when has xref location in macro', () => {
       const input = heredoc`
         = Page Title


### PR DESCRIPTION
Fix `lib/javadoc-extension.js` so that package lookups also work when the package has a single component. Prior to this commit, a lookup such as `javadoc-location-java: '{url-jdk-javadoc}'` would not work.
