### PR TITLE
Block attributes are ignored when determining chomp package replacement

### DIFF
--- a/lib/code-chomping-extension.js
+++ b/lib/code-chomping-extension.js
@@ -26,15 +26,16 @@ function createExtensionGroup () {
     this.treeProcessor(function () {
       this.process((doc) => {
         const chompDefault = doc.getAttribute('chomp', 'default')
-        const package_ = doc.getAttribute('chomp_package_replacement') ?? doc.getAttribute('chomp-package-replacement')
+        const packageReplacementDefault = getPackageReplacement(doc)
         const blocks = doc.findBy(
           { context: 'listing' },
           (candidate) => candidate.getStyle() === 'source' && JAVA_LIKE.includes(candidate.getAttribute('language'))
         )
         blocks.forEach((block) => {
           const chomp = block.getAttribute('chomp', chompDefault)
+          const packageReplacement = getPackageReplacement(block) ?? packageReplacementDefault
           const ops = (CHOMP_MODES[chomp] || [chomp]).reduce((accum, mode) => (accum[mode] = true) && accum, {})
-          if (ops.packages && package_ != null) ops.packages = package_
+          if (ops.packages && packageReplacement != null) ops.packages = packageReplacement
           let skipRest, match
           block.lines = block.getSourceLines().reduce((accum, line) => {
             if (skipRest) return accum
@@ -70,6 +71,10 @@ function createExtensionGroup () {
       })
     })
   }
+}
+
+function getPackageReplacement (element) {
+  return element.getAttribute('chomp_package_replacement') ?? element.getAttribute('chomp-package-replacement')
 }
 
 module.exports = { register, createExtensionGroup }

--- a/test/code-chomping-extension-test.js
+++ b/test/code-chomping-extension-test.js
@@ -261,6 +261,29 @@ describe('code-chomping-extension', () => {
       expect(actual).to.equal(expected)
     })
 
+    it('should replace package declaration when configured on the block', () => {
+      const code = heredoc`
+      package org.example;
+
+      public class Example {}
+      `
+
+      const input = heredoc`
+      :chomp: packages
+      :chomp_package_replacement: org.acme
+
+      [chomp_package_replacement=com.acme]
+      [,java]
+      ----
+      ${code}
+      ----
+      `
+
+      const expected = code.replace('package org.example', 'package com.acme')
+      const actual = run(input).getBlocks()[0].getSource()
+      expect(actual).to.equal(expected)
+    })
+
     it('should remove remaining lines after @chomp:file', () => {
       const input = heredoc`
       [,java]


### PR DESCRIPTION
Without this change, configuring `chomp-package-replacement` at the block level (rather than the document level) has no effect. `chomp` can already be configured at the block level so this change aligns the two.