### PR TITLE
Blocks for included code lose attributes declared on the macro

### DIFF
--- a/lib/include-code-extension.js
+++ b/lib/include-code-extension.js
@@ -30,7 +30,7 @@ function createExtensionGroup (context) {
         if (!langs.length) return log(doc, 'warn', `no search locations defined for include-code::${target}[]`)
         const cursor = doc.getReader().$cursor_at_mark()
         tabsEnabled ??= doc.getExtensions().hasBlocks() && !!doc.getExtensions().getBlockFor('tabs', 'example')
-        const attrsStr = Object.entries(attrs).reduce((buf, [n, v]) => `${buf}${buf ? ',' : ''}${n}=${v}`, '')
+        const attrsStr = Object.entries(attrs).filter(([n, v]) => n != 'title').reduce((buf, [n, v]) => `${buf}${buf ? ',' : ''}${n}=${v}`, '')
         const sectionId = (nearest(parent, 'section') || doc).getId()
         const relativeIdPath = sectionId
           ? sectionId.replaceAll('-', '').replaceAll('.', '/') + '/' + sanitizedTarget
@@ -47,7 +47,7 @@ function createExtensionGroup (context) {
           return accum.concat({ name, lang, lines })
         }, [])
         if (!includes.length) return log(doc, 'warn', `no code includes found for ${target}`)
-        const tabsSource = generateTabsSource(attrs.title, attrs['sync-group-id'], includes, tabsEnabled)
+        const tabsSource = generateTabsSource(attrs.title, attrs['sync-group-id'], includes, tabsEnabled, attrsStr)
         const reader = PreprocessorReader.$new(doc, tabsSource, cursor)
         Object.defineProperty(reader, 'lineno', { get: () => cursor.lineno })
         return this.parseContent(parent, reader)
@@ -56,10 +56,11 @@ function createExtensionGroup (context) {
   }
 }
 
-function generateTabsSource (title, syncGroupId, includes, tabsEnabled) {
+function generateTabsSource (title, syncGroupId, includes, tabsEnabled, attrsStr) {
   const source = []
   if (includes.length === 1) {
     if (title) source.push('.' + title)
+    source.push(`[${attrsStr}]`)
     source.push(`[,${includes[0].lang}]`, '----', ...includes[0].lines, '----')
   } else if (tabsEnabled) {
     if (title) source.push('.' + title)
@@ -67,13 +68,13 @@ function generateTabsSource (title, syncGroupId, includes, tabsEnabled) {
     const tabAttrs = syncGroupId ? `,sync-group-id=${syncGroupId}` : ''
     includes.forEach(({ name, lang, lines }, idx) => {
       idx ? source.push('') : source.push(`[tabs${tabAttrs}]`, '======')
-      source.push(`${name}::`, '+', `[,${lang}]`, '----', ...lines, '----')
+      source.push(`${name}::`, '+', `[${attrsStr}]`, `[,${lang}]`, '----', ...lines, '----')
       if (idx === lastIdx) source.push('======')
     })
   } else {
     includes.forEach(({ name, lang, lines }) => {
       if (source.length) source.push('')
-      source.push('.' + (title ? title + ' - ' + name : name), `[,${lang}]`, '----', ...lines, '----')
+      source.push('.' + (title ? title + ' - ' + name : name), `[${attrsStr}]`, `[,${lang}]`, '----', ...lines, '----')
     })
   }
   return source

--- a/test/include-code-extension-test.js
+++ b/test/include-code-extension-test.js
@@ -211,6 +211,24 @@ describe('include-code-extension', () => {
       expect(actual.getBlocks()[0].getTitle()).to.equal('Describe This')
     })
 
+    it('should pass attribute on block macro for single include through to resulting source block', () => {
+      const inputSource = heredoc`
+      package org.example
+
+      fun main(args : Array<String>) {
+        println("Hello, World!")
+      }
+      `
+      addExample('kotlin/hello.kt', inputSource)
+      const input = heredoc`
+      [some-attribute=alpha]
+      include-code::hello[]
+      `
+      const actual = run(input, { attributes: { 'include-kotlin': 'example$kotlin' } })
+      expect(actual.getBlocks()).to.have.lengthOf(1)
+      expect(actual.getBlocks()[0].getAttribute('some-attribute')).to.equal('alpha')
+    })
+
     it('should report correct line number in warning for block title', () => {
       const inputSource = heredoc`
       fun main(args : Array<String>) {
@@ -261,6 +279,35 @@ describe('include-code-extension', () => {
       expect(actual.getBlocks()).to.have.lengthOf(2)
       expect(actual.getBlocks()[0].getTitle()).to.equal('Describe This - Java')
       expect(actual.getBlocks()[1].getTitle()).to.equal('Describe This - Kotlin')
+    })
+
+    it('should pass attribute on block macro for multiple includes through to resulting source block', () => {
+      addExample(
+        'kotlin/hello.kt',
+        heredoc`
+        fun main(args : Array<String>) {
+          println("Hello, World!")
+        }
+        `
+      )
+      addExample(
+        'java/hello.java',
+        heredoc`
+        public class Hello {
+          public static void main (String[] args) {
+            System.out.println("Hello, World!");
+          }
+        }
+        `
+      )
+      const input = heredoc`
+      [some-attribute=alpha]
+      include-code::hello[]
+      `
+      const actual = run(input)
+      expect(actual.getBlocks()).to.have.lengthOf(2)
+      expect(actual.getBlocks()[0].getAttribute('some-attribute')).to.equal('alpha')
+      expect(actual.getBlocks()[1].getAttribute('some-attribute')).to.equal('alpha')
     })
 
     it('should support attributes on include directive of included file', () => {
@@ -414,6 +461,54 @@ describe('include-code-extension', () => {
       const actualProperties = codeBlocks.map((block) => {
         return { style: block.getStyle(), language: block.getAttributes().language, title: block.getTitle() }
       })
+      expect(actualProperties).to.eql(expected)
+    })
+
+    it('should pass attribute on block macro to each tabbed block if @asciidoctor/tabs extension is registered', () => {
+      const expected = [
+        { style: 'source', language: 'java', title: undefined, someAttribute: 'alpha' },
+        { style: 'source', language: 'kotlin', title: undefined, someAttribute: 'alpha' },
+        { style: 'source', language: 'groovy', title: undefined, someAttribute: 'alpha' },
+        { style: 'source', language: 'xml', title: undefined, someAttribute: 'alpha' },
+      ]
+      addExample(
+        'kotlin/hello.kt',
+        heredoc`
+        fun main(args : Array<String>) {
+          println("Hello, World!")
+        }
+        `
+      )
+      addExample(
+        'java/hello.java',
+        heredoc`
+        public class Hello {
+          public static void main (String[] args) {
+            System.out.println("Hello, World!");
+          }
+        }
+        `
+      )
+      addExample('groovy/hello.groovy', 'println "Hello, World!"')
+      addExample('xml/hello.xml', 'println "<hello />"')
+      const input = heredoc`
+      [some-attribute=alpha]
+      include-code::hello[]`
+      const doc = run(input, { registerAsciidoctorTabs: true })
+      const tabs = doc.getBlocks()[0]
+      console.log(tabs)
+      expect(tabs).to.exist()
+      expect(tabs.hasRole('tabs')).to.be.true()
+      expect(tabs.getTitle()).to.be.undefined()
+      const tablist = tabs.findBy({ context: 'ulist' })[0]
+      expect(tablist).to.exist()
+      expect(tablist.getItems()).to.have.lengthOf(4)
+      const codeBlocks = tabs.findBy({ context: 'listing' })
+      expect(codeBlocks).to.have.lengthOf(4)
+      const actualProperties = codeBlocks.map((block) => {
+        return { style: block.getStyle(), language: block.getAttributes().language, title: block.getTitle(), someAttribute: block.getAttribute('some-attribute') }
+      })
+      console.log(actualProperties)
       expect(actualProperties).to.eql(expected)
     })
 


### PR DESCRIPTION
Without this change, configuring `chomp-package-replacement` when using `include-code::[]` has no effect.