### PR TITLE
Support multi-line yaml to properties conversion

### DIFF
--- a/lib/configuration-properties-extension.js
+++ b/lib/configuration-properties-extension.js
@@ -97,6 +97,16 @@ class YamlToPropertiesConverter {
     if (type === Array) {
       return val.reduce((accum, it, idx) => accum.concat(this.toProperty(`${key}[${idx}]`, it, prefix, true)), [])
     }
+    if ((typeof val === 'string' || val instanceof String) && val.includes('\n')) {
+      const lines = val.split('\n').slice(0, -1)
+      const lastIdx = lines.length - 1
+      val = lines.reduce((accum, it, idx) => {
+        accum = accum.concat(`${it}\\n`)
+        if (idx !== lastIdx) accum = accum.concat('\\\n')
+        if (idx === 0) accum = '\\\n'.concat(accum)
+        return accum
+      }, '')
+    }
     return [`${propertyName}=${val}`]
   }
 }

--- a/lib/include-code-extension.js
+++ b/lib/include-code-extension.js
@@ -30,7 +30,9 @@ function createExtensionGroup (context) {
         if (!langs.length) return log(doc, 'warn', `no search locations defined for include-code::${target}[]`)
         const cursor = doc.getReader().$cursor_at_mark()
         tabsEnabled ??= doc.getExtensions().hasBlocks() && !!doc.getExtensions().getBlockFor('tabs', 'example')
-        const attrsStr = Object.entries(attrs).filter(([n, v]) => n !== 'title').reduce((buf, [n, v]) => `${buf}${buf ? ',' : ''}${n}=${v}`, '')
+        const attrsStr = Object.entries(attrs)
+          .filter(([n, v]) => n !== 'title')
+          .reduce((buf, [n, v]) => `${buf}${buf ? ',' : ''}${n}=${v}`, '')
         const sectionId = (nearest(parent, 'section') || doc).getId()
         const relativeIdPath = sectionId
           ? sectionId.replaceAll('-', '').replaceAll('.', '/') + '/' + sanitizedTarget

--- a/test/configuration-properties-extension-test.js
+++ b/test/configuration-properties-extension-test.js
@@ -666,6 +666,26 @@ describe('configuration-properties-extension', () => {
         expect(propertiesBlock.getSourceLines()).to.eql(expected)
       })
 
+      it('should convert multi-line property in configprops,yaml block to properties', () => {
+        addConfigurationMetadataFixture()
+        const input = heredoc`
+        [configprops,yaml]
+        ----
+        foo:
+          bar:
+            baz: |
+              one
+              two
+              three
+        ----
+        `
+        expect(messages).to.be.empty()
+        const actual = run(input)
+        const propertiesBlock = actual.findBy({ context: 'listing' })[0]
+        const expected = ['foo.bar.baz=\\', 'one\\n\\', 'two\\n\\', 'three\\n']
+        expect(propertiesBlock.getSourceLines()).to.eql(expected)
+      })
+
       it('should only warn once if invalid property is used in multiple documents in configprops,yaml block', () => {
         const input = heredoc`
         [configprops,yaml]

--- a/test/include-code-extension-test.js
+++ b/test/include-code-extension-test.js
@@ -507,7 +507,12 @@ describe('include-code-extension', () => {
       const codeBlocks = tabs.findBy({ context: 'listing' })
       expect(codeBlocks).to.have.lengthOf(4)
       const actualProperties = codeBlocks.map((block) => {
-        return { style: block.getStyle(), language: block.getAttributes().language, title: block.getTitle(), someAttribute: block.getAttribute('some-attribute') }
+        return {
+          style: block.getStyle(),
+          language: block.getAttributes().language,
+          title: block.getTitle(),
+          someAttribute: block.getAttribute('some-attribute'),
+        }
       })
       console.log(actualProperties)
       expect(actualProperties).to.eql(expected)


### PR DESCRIPTION
This adds functionality that's (hopefully) equivalent to https://github.com/spring-io/spring-asciidoctor-extensions/issues/94.