### PR TITLE
Preserve ellipsis

### DIFF
--- a/lib/javadoc-extension.js
+++ b/lib/javadoc-extension.js
@@ -23,7 +23,7 @@ function createExtensionGroup () {
 }
 
 function parseTarget (target) {
-  target = target.replaceAll('&#8230;&#8203;', '...')
+  target = target.replaceAll('&#8230;&#8203;', '\\...')
   const lastSlash = target.lastIndexOf('/')
   const location = lastSlash !== -1 ? target.substring(0, lastSlash) : undefined
   const reference = lastSlash !== -1 ? target.substring(lastSlash + 1, target.length) : target

--- a/test/javadoc-extension-test.js
+++ b/test/javadoc-extension-test.js
@@ -295,7 +295,7 @@ describe('javadoc-extension', () => {
       `
       const actual = run(input)
       expect(actual).to.include(
-        '<a href="https://docs.example.com/_attachments/api/java/com/example/MyClass.html#run(java.lang.Class,java.lang.String&#8230;&#8203;)" class="xref page apiref"><code>MyClass.run(Class, String&#8230;&#8203;)</code></a>'
+        '<a href="https://docs.example.com/_attachments/api/java/com/example/MyClass.html#run(java.lang.Class,java.lang.String...)" class="xref page apiref"><code>MyClass.run(Class, String...)</code></a>'
       )
     })
 


### PR DESCRIPTION
When I read the section `Using the Test Configuration Main Method` and click `SpringApplication.run(Class, String…​)`, a javadoc page will be opened but it's not link to method because the javadoc link has an ellipsis and the ellipsis is followed by a zero-width space (`%E2%80%8B`)

Document
https://docs.spring.io/spring-boot/reference/testing/spring-boot-applications.html#testing.spring-boot-applications.using-main